### PR TITLE
Put persistent state on a detachable volume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,15 @@ DOMAIN=
 # version (e.g. "0.2.0") to pin.
 # TNG_IMAGE_TAG=develop
 
+# Directory on the host holding everything that cannot be regenerated: the
+# SQLite database (data/) and Caddy's ACME account key and certificates
+# (caddy/data/, caddy/config/).  On a server this should point at a mount that
+# outlives the machine — on Digital Ocean, a Block Storage volume mounted at
+# /mnt/tng.  See README.md § Persistent state.
+# Leave unset for local development, where it defaults to ./state in the
+# checkout.
+# TNG_STATE_DIR=/mnt/tng
+
 # ── Slack ─────────────────────────────────────────────────────────────────────
 
 # Bot token for the TNG Slack app (xoxb-...). Used to send login links and

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ dev.dockerfile
 run_server.sh
 .env.development
 data
+state
 box_auth.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+#### Persistent state on a detachable volume (#3)
+
+- `docker-compose.yml` no longer keeps the database or Caddy's certificates in Docker `local`
+  named volumes. Those live under `/var/lib/docker/volumes` on the host's boot disk, and a
+  Digital Ocean droplet's boot disk cannot be detached — it is destroyed with the droplet. They
+  are now bind mounts under `${TNG_STATE_DIR:-./state}`: `data/`, `caddy/data/`, and
+  `caddy/config/`.
+- `TNG_STATE_DIR` is a new optional setting. Unset, it resolves to `./state` in the checkout and
+  local development is unaffected; on the droplet it is set to `/mnt/tng`, a Block Storage volume
+  that survives the droplet.
+- `music-workspace` remains a named volume. It holds the clone of the music repository and the
+  rendered SVG/PDF output, all of which the next sync reproduces, and it is the bulky one.
+- `README.md` gains a *Persistent state* section describing the layout — including `.env`, which
+  now lives on the volume and is symlinked into the checkout — a volume-provisioning step in the
+  Digital Ocean walkthrough, and a procedure for migrating an already-running droplet off its
+  named volumes without losing the database.
+
 #### CeolKit 1.2.1 → 1.3.0
 
 - `Package.swift` now requires CeolKit `from: "1.3.0"`. No application code changed; the build and

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ each value before starting the stack.
 |---|---|
 | `DOMAIN` | Public hostname, e.g. `musictools.siliconvalleypipeband.com` — used by Caddy for TLS |
 | `TNG_IMAGE_TAG` | Optional. Which published image to run: `develop`, a release version, or unset for `latest` |
+| `TNG_STATE_DIR` | Optional. Host directory holding the database and Caddy's certificates. Defaults to `./state` in the checkout; on a server, point it at a mount that outlives the machine — see [Persistent state](#persistent-state) |
 | `GITHUB_WEBHOOK_SECRET` | Shared secret configured in the GitHub webhook settings |
 | `SVPB_MUSIC_REPO_URL` | HTTPS clone URL of the `svpb-music` repository |
 | `BOX_CLIENT_ID` | Box OAuth2 application client ID |
@@ -153,12 +154,39 @@ docker compose down
 ## Deployment
 
 TNG is distributed as a `docker-compose.yml` that starts two containers — the TNG server and a
-Caddy reverse proxy — plus named volumes for the database and the music workspace. Any host that
-can run Docker Compose and is reachable on ports 80 and 443 will work.
+Caddy reverse proxy — plus a bind-mounted state directory and one named volume for the music
+workspace. Any host that can run Docker Compose and is reachable on ports 80 and 443 will work.
 
 Images are built by GitHub Actions and published to
 `ghcr.io/svpb/svpb-tools`. The server pulls them; it never compiles Swift. See
 [HOSTING_OPTIONS.md](HOSTING_OPTIONS.md) for a comparison of providers.
+
+### Persistent state
+
+Everything TNG cannot regenerate lives under one directory, named by `TNG_STATE_DIR`:
+
+```
+$TNG_STATE_DIR/
+├── .env            # secrets and configuration; symlinked into the checkout
+├── data/           # SQLite database — users, build history, tune catalogue, binder requests
+└── caddy/
+    ├── data/       # ACME account key and issued TLS certificates
+    └── config/     # Caddy's autosaved config
+```
+
+`TNG_STATE_DIR` defaults to `./state` inside the checkout, which is what local development wants.
+On a server, point it at storage that survives the machine — the whole point being that a droplet's
+boot disk does not. The music workspace (the clone of the music repository and the rendered
+SVG/PDF output) deliberately stays a plain named Docker volume: it is reproducible from the next
+sync and expensive to store.
+
+Note the `.env` in that listing. It is a fifth piece of unreplaceable state, it cannot be committed,
+and it is not reconstructable without re-running `box-auth` and re-reading every credential out of
+Box, Slack, and GitHub — so it belongs on the same durable storage, symlinked back into the
+checkout where `docker compose` expects to find it.
+
+This protects against losing the machine. It does **not** protect against database corruption, a
+bad migration, or `docker compose down -v`; backups are a separate concern.
 
 ### Digital Ocean Droplet
 
@@ -187,7 +215,24 @@ apt-get update
 apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 ```
 
-**5. Add swap.** 2 GB of RAM is comfortable for normal operation, but rendering a full year of
+**5. Attach a block storage volume.** In the Digital Ocean control panel, create a Volume in the
+droplet's region — 1 GiB is the minimum and is ample — name it `tng-state`, and attach it to the
+droplet. Digital Ocean offers to format and mount it for you; the commands below do the same thing
+explicitly. Use the `by-id` path rather than `/dev/sda`, which is not stable across reboots.
+
+```sh
+DEV=/dev/disk/by-id/scsi-0DO_Volume_tng-state
+mkfs.ext4 -F "$DEV"                     # ONLY on a brand-new volume — this erases it
+mkdir -p /mnt/tng
+echo "$DEV /mnt/tng ext4 defaults,nofail,discard 0 2" >> /etc/fstab
+mount -a
+mkdir -p /mnt/tng/data /mnt/tng/caddy/data /mnt/tng/caddy/config
+```
+
+Volumes cost $0.10/GiB/month, can be resized up (never down), survive the droplet's destruction,
+and can be snapshotted independently of it.
+
+**6. Add swap.** 2 GB of RAM is comfortable for normal operation, but rendering a full year of
 music in one sync can spike. Swap costs nothing and prevents an OOM kill.
 
 ```sh
@@ -195,21 +240,63 @@ fallocate -l 2G /swapfile && chmod 600 /swapfile && mkswap /swapfile && swapon /
 echo '/swapfile none swap sw 0 0' >> /etc/fstab
 ```
 
-**6. Deploy.**
+**7. Deploy.**
+
+The `.env` lives on the volume and is symlinked into the checkout, so that destroying and
+recreating the droplet loses nothing but the checkout itself.
 
 ```sh
 git clone https://github.com/SVPB/svpb-tools.git
 cd svpb-tools
-cp .env.example .env
-# edit .env — every value in the Configuration table above
+cp .env.example /mnt/tng/.env
+chmod 600 /mnt/tng/.env
+# edit /mnt/tng/.env — every value in the Configuration table above,
+# and uncomment TNG_STATE_DIR=/mnt/tng
+ln -s /mnt/tng/.env .env
 docker compose up -d
 ```
 
-**7. Verify.** `docker compose ps` should show both containers healthy, and
+**8. Verify.** `docker compose ps` should show both containers healthy, and
 `curl https://<your-domain>/health` should return JSON. If Caddy cannot get a certificate,
 `docker compose logs caddy` says why — almost always DNS not yet propagated or port 80 blocked.
 
-Estimated cost: **$12/month** for the droplet. The cloud firewall is free.
+Estimated cost: **$12/month** for the droplet plus **$0.10/month** for a 1 GiB volume. The cloud
+firewall is free.
+
+#### Migrating an existing droplet onto a block volume
+
+If the stack is already running with its state in Docker `local` named volumes — that is, on the
+droplet's boot disk — move it onto the volume without losing the database. Do step 5 above first to
+create, format, and mount the volume, then, from the checkout:
+
+```sh
+docker compose down                        # NOT -v: that would delete the volumes you are copying
+
+# The compose project name prefixes the volume names; it defaults to the
+# directory name, so these are usually svpb-tools_*. Confirm with `docker volume ls`.
+docker run --rm -v svpb-tools_tng-data:/from -v /mnt/tng/data:/to \
+  alpine sh -c 'cp -a /from/. /to/'
+docker run --rm -v svpb-tools_caddy-data:/from -v /mnt/tng/caddy/data:/to \
+  alpine sh -c 'cp -a /from/. /to/'
+docker run --rm -v svpb-tools_caddy-config:/from -v /mnt/tng/caddy/config:/to \
+  alpine sh -c 'cp -a /from/. /to/'
+
+mv .env /mnt/tng/.env
+chmod 600 /mnt/tng/.env
+ln -s /mnt/tng/.env .env
+echo 'TNG_STATE_DIR=/mnt/tng' >> /mnt/tng/.env
+
+git pull                                   # picks up the bind-mount compose file
+docker compose up -d
+```
+
+Verify before cleaning up: `ls -l /mnt/tng/data/tng.sqlite` should show the database at its
+previous size, and the admin dashboard should still list the prior build history rather than
+looking freshly initialised. Only once you are satisfied, reclaim the boot-disk copies:
+
+```sh
+docker volume rm svpb-tools_tng-data svpb-tools_caddy-data svpb-tools_caddy-config
+```
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,13 @@ services:
       # stale value in .env is harmless.
       - MUSIC_WORKSPACE_PATH=/app/music
     volumes:
-      - tng-data:/app/data
+      # Persistent state lives under TNG_STATE_DIR so it can be pointed at a
+      # detachable block volume in production (see README § Persistent state).
+      # Unset, it falls back to ./state in the checkout, which is what local
+      # development wants.
+      - ${TNG_STATE_DIR:-./state}/data:/app/data
+      # The workspace is a clone of the music repo plus rendered output: both
+      # are reproducible from the next sync, so it stays a plain named volume.
       - music-workspace:/app/music
     # TNG is not exposed directly — all traffic flows through Caddy.
     expose:
@@ -37,13 +43,12 @@ services:
       - "443:443/udp"   # HTTP/3
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      - caddy-data:/data
-      - caddy-config:/config
+      # The ACME account key and issued certificates: replaceable in principle,
+      # but re-issuing on every rebuild burns Let's Encrypt rate limits.
+      - ${TNG_STATE_DIR:-./state}/caddy/data:/data
+      - ${TNG_STATE_DIR:-./state}/caddy/config:/config
     environment:
       - DOMAIN=${DOMAIN}
 
 volumes:
-  tng-data:
   music-workspace:
-  caddy-data:
-  caddy-config:


### PR DESCRIPTION
Closes #3.

`tng-data`, `caddy-data`, and `caddy-config` were Docker `local` named volumes, so they lived
under `/var/lib/docker/volumes` on the droplet's **boot disk** — which, unlike an EBS root volume,
cannot be detached and is destroyed with the droplet. This moves them onto a bind-mounted state
directory that can point at a DigitalOcean Block Storage volume.

### Changes

- **`docker-compose.yml`** — the three state mounts become bind mounts under
  `${TNG_STATE_DIR:-./state}` (`data/`, `caddy/data/`, `caddy/config/`). `music-workspace` stays a
  named volume: the clone of the music repository and the rendered SVG/PDF output are reproducible
  from the next sync, and it is the bulky one.
- **`.env.example`** — documents the new optional `TNG_STATE_DIR`. Unset it resolves to `./state`
  in the checkout, so local development is unaffected; on the droplet it is `/mnt/tng`.
- **`.gitignore`** — ignores `state/`.
- **`README.md`** — a *Persistent state* section describing the layout (including `.env`, which
  moves onto the volume and is symlinked into the checkout), a volume-provisioning step in the
  Digital Ocean walkthrough using the stable `/dev/disk/by-id/scsi-0DO_Volume_tng-state` path plus
  an `fstab` entry, and a *Migrating an existing droplet* subsection.
- **`CHANGELOG.md`** — entry under Unreleased → Changed.

### Verification

`docker compose config` was run against a scratch copy of the compose file in three
configurations, checking the resolved mount sources:

| Config | `/app/data` resolves to |
|---|---|
| `TNG_STATE_DIR` unset | `<checkout>/state/data` |
| `TNG_STATE_DIR=/mnt/tng` | `/mnt/tng/data` |
| `TNG_STATE_DIR` set inside a **symlinked** `.env` | the target directory |

The third case is the one the deployment actually depends on, and it confirms Compose follows the
`.env` symlink for both variable interpolation and `env_file`.

No application code changed; nothing here affects the test suite.

### Before merging/deploying

- The migration commands assume the compose project name is `svpb-tools` (volumes
  `svpb-tools_tng-data` etc.). Confirm with `docker volume ls` on the droplet — the prefix follows
  the checkout directory name.
- `mkfs.ext4` in step 5 is the one destructive command in the doc and is commented as
  new-volumes-only. The `tng-state` volume already exists; if DigitalOcean formatted it at attach
  time, `lsblk -f` will show ext4 and the `mkfs` should be skipped.
- The migration deliberately uses `docker compose down`, never `-v`, and defers
  `docker volume rm` until after the admin dashboard has been checked for prior build history.

This protects against droplet loss only. It does **not** protect against DB corruption, a bad
migration, or `docker compose down -v` — see #4, which is complementary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeYSiYAPmDCrBW3X2vDP5r
